### PR TITLE
A couple small fixes for kernelci branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN echo 'lava-server   lava-server/instance-name string lava-docker-instance' |
  qemu-system \
  && a2dissite 000-default \
  && a2ensite lava-server \
+ && a2enmod proxy* \
  && /stop.sh \
  && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN echo 'lava-server   lava-server/instance-name string lava-docker-instance' |
  && DEBIAN_FRONTEND=noninteractive apt-get install -y -t jessie-backports \
  lava \
  qemu-system \
+ qemu-system-arm \
  && a2dissite 000-default \
  && a2ensite lava-server \
  && a2enmod proxy* \


### PR DESCRIPTION
The apache2 proxy fix is needed for "docker build" to work.
The qemu-system-arm change is needed because arm64 kernel builds require newer qemu-system-aarch64
